### PR TITLE
Exception improved for async work

### DIFF
--- a/django_tex/exceptions.py
+++ b/django_tex/exceptions.py
@@ -49,6 +49,7 @@ class TexError(Exception):
             )
 
             self.message += "\n\n" + template_context
+            super(TexError, self).__init__(log, source, template_name)
 
     def __str__(self):
         return self.message


### PR DESCRIPTION
I run into an Error using django-tex with celery and celery results. The error was:


> [2022-03-21 21:25:10,946: ERROR/MainProcess] Task handler raised error: <MaybeEncodingError: Error sending result: ''(1, <ExceptionInfo: TexError()>, None)''. Reason: ''PicklingError("Can\'t pickle <class \'django_tex.exceptions.TexError\'>: it\'s not the same object as django_tex.exceptions.TexError")''.>

By adding this line of code, the issue is solved. 

Check following issue for more: https://github.com/celery/celery/issues/3623
https://github.com/celery/celery/issues/3623#issuecomment-264564267
